### PR TITLE
fix: Torvmarksform havner utenfor natursystem i data.artsdatabanken.no

### DIFF
--- a/type.json
+++ b/type.json
@@ -95,7 +95,9 @@
     }
   },
   "NN-NA-BS-3TO": {
-    "url": "Torvmarksform"
+    "tittel": {
+      "url": "Torvmarksform"
+    }
   },
   "NN-NA-BS-6SO": {
     "farge": "rgb(253,194,111)",


### PR DESCRIPTION
Fant ut at url må ha hele urlen mens tittel.url bare trenger det siste segmentet.  

Etter å ha kjørt nin-data-lastejobb blir diff etter denne justeringen:

```
-  "Torvmarksform/Bakkemyr"
+ "/Natur_i_Norge/Natursystem/Beskrivelsessystem/Landform/Torvmarksform/Bakkemyr"
```